### PR TITLE
Add additional landfill features

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ http {
         moz_ingest_header                   User-Agent;
         moz_ingest_landfill_dir             /mnt/landfill;
         moz_ingest_landfill_roll_size       300M;
+        moz_ingest_landfill_roll_timeout    60m;
 
 
         location /submit/telemetry/ {
@@ -149,6 +150,16 @@ extension) and a new file created.
 
     Syntax: moz_ingest_landfill_roll_size size;
     Default: 300M
+    Context: main, http, server, location
+
+#### moz_ingest_landfill_roll_timeout
+Specifies the landfill timeout when the file will be finalized even if it has not
+reached the roll size. This is driven by incoming requests to the location (per process)
+and not by a timer i.e., if a single request is sent to the location the file will never
+be rolled due to a timeout, it will only be finalized on Nginx shutdown.
+
+    Syntax: moz_ingest_landfill_roll_timeout seconds;
+    Default: 60m
     Context: main, http, server, location
 
 #### moz_ingest_landfill_name

--- a/src/ngx_http_moz_ingest_module.h
+++ b/src/ngx_http_moz_ingest_module.h
@@ -43,6 +43,7 @@ typedef struct {
 
   // Landfill settings (alternate S3 load mechanism)
   size_t      landfill_roll_size;
+  time_t      landfill_roll_timeout;
   ngx_str_t   landfill_dir;
   ngx_str_t   landfill_name;
 } ngx_http_moz_ingest_loc_conf_t;


### PR DESCRIPTION
- add a moz_ingest_landfill_roll_timeout configuration option
- if a message is successfully written to landfill do not fail the
  request if the Kafka queuing fails (log a warning)
